### PR TITLE
disabled menubar for windows

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,7 +3,12 @@ const path = require('path');
 const iconPath = path.join(__dirname, "build", "icon.png");
 
 function createWindow () {
-    win = new BrowserWindow({fullscreen: true, icon: iconPath});
+    win = new BrowserWindow(
+      {
+        fullscreen: true,
+        icon: iconPath,
+        autoHideMenuBar: true
+      });
     win.loadURL('http://youtube.com/tv',
       {userAgent: 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36; Youtube ; Tizen 4.0'});
  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
  "name": "youtube-cast-receiver",
- "version": "1.0.0",
+ "version": "1.0.1",
  "author": "Garrett Blackmon <garrett@blackmon.dev>",
  "description": "Grants access to youtube.com/tv normally reserved for use with smart TVs",
  "main": "main.js",


### PR DESCRIPTION
Hotfix for issue #3 

disables the top menubar for windows distributions.

### Before:
![image](https://user-images.githubusercontent.com/5715535/156697961-2f142918-dc3f-4e75-826f-b7210daa2dbf.png)

### After:
![image](https://user-images.githubusercontent.com/5715535/156698064-9eb67294-dd0f-4ba7-8429-173ce1675b60.png)