### PR TITLE
Updated user agent for 1080p playback

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@ function createWindow () {
         autoHideMenuBar: true
       });
     win.loadURL('http://youtube.com/tv',
-      {userAgent: 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36; Youtube ; Tizen 4.0'});
+      {userAgent: 'Mozilla/5.0 (PS4; Leanback Shell) Gecko/20100101 Firefox/65.0 LeanbackShell/01.00.01.75 Sony PS4/ (PS4, , no, CH)'});
  
     win.on('closed', () => {
       win = null


### PR DESCRIPTION
Using the app with the original user agent, most videos were limited to 720p. Using this new user agent (found [here](https://www.reddit.com/r/htpc/comments/y5o7mi/youtube_leanback_tv_useragent_for_4k_60fps/)) it's possible to watch in 1080p and maybe even 4k (not tested as I don't own a 4k display)